### PR TITLE
add school in `getAll` function response

### DIFF
--- a/modules/classes/character.js
+++ b/modules/classes/character.js
@@ -216,7 +216,8 @@ module.exports = class Character extends require("./template") {
 				role: data.role,
 				squadType: data.squadType,
 				weaponType: data.weaponType,
-				terrain: charData.topology
+				terrain: charData.topology,
+				school: data.school
 			};
 		}
 


### PR DESCRIPTION
I previously created an issue (#2) for adding the support to get all characters, in the example response I gave, it has `school` in the response, but it seems that I didn't check thoroughly the first time and it turns out `school` is not in the response after using your API for a while.

So this PR is for adding `school` in the response for `getAll` function for getting all characters.